### PR TITLE
Fix env loading priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build
 
 # misc
+.env
 .DS_Store
 .env.local
 .env.development.local

--- a/.sandbox/manifest.yaml
+++ b/.sandbox/manifest.yaml
@@ -1,6 +1,3 @@
-env:
-  - REACT_APP_BACKEND_API_URL=http://$BACKEND_SERVICE_HOST:$BACKEND_SERVICE_PORT
-
 hooks:
   post-checkout:
     cmd: npm install


### PR DESCRIPTION
Variables supplied via `.env` file should take priority over manifest defined envs.